### PR TITLE
修复CI编译错误问题

### DIFF
--- a/sdk-bsp-imxrt1052-nxp-evk.yaml
+++ b/sdk-bsp-imxrt1052-nxp-evk.yaml
@@ -67,7 +67,7 @@ default_projects:
     - include
     - libcpu/arm
     - libcpu/Kconfig
-    - libcpu/Sconscript
+    - libcpu/SConscript
     - src
     - tools
     - Kconfig
@@ -125,7 +125,7 @@ default_projects:
     - include
     - libcpu/arm
     - libcpu/Kconfig
-    - libcpu/Sconscript
+    - libcpu/SConscript
     - src
     - tools
     - Kconfig


### PR DESCRIPTION
yaml配置的源码包依赖时，files_and_folders字段的值 SConscript 中的 SC改为大写